### PR TITLE
fix children array problem

### DIFF
--- a/index.js
+++ b/index.js
@@ -531,7 +531,8 @@ HtmlResWebpackPlugin.prototype.inlineHtmlRes = function(routeStr, reg, publicPat
 					else if (!!~item.indexOf("." + extension) && extension === "css") {
 						file = "";
 						let cssContent = "";
-						compilation.assets[item].children.forEach(function(item) {
+						let children = compilation.assets[item].children || [];
+						children.forEach(function(item) {
 							cssContent += item._value;
 						}) ;
 						file = "<style>" + cssContent + "</style>";


### PR DESCRIPTION
当children属性不是数组时，赋值为一个空数组